### PR TITLE
Refactor: Remove plan override when creating a subscription

### DIFF
--- a/welcomer-backend/backend/routes_billing.go
+++ b/welcomer-backend/backend/routes_billing.go
@@ -264,27 +264,27 @@ func createPaymentSubscription(ctx *gin.Context, sku welcomer.PricingSKU, applic
 		AutoRenewal:        true,
 		ApplicationContext: applicationContext,
 		CustomID:           userTransaction.TransactionUuid.String(),
-		Plan: &paypal.PlanOverride{
-			BillingCycles: []paypal.BillingCycleOverride{
-				{
-					Sequence:    utils.ToPointer(1),
-					TotalCycles: utils.ToPointer(1),
-					PricingScheme: paypal.PricingScheme{
-						FixedPrice: paypal.Money{
-							Currency: money.Currency,
-							Value:    "0",
-						},
-					},
-				},
-				{
-					Sequence:    utils.ToPointer(2),
-					TotalCycles: utils.ToPointer(0),
-					PricingScheme: paypal.PricingScheme{
-						FixedPrice: *money,
-					},
-				},
-			},
-		},
+		// Plan: &paypal.PlanOverride{
+		// 	BillingCycles: []paypal.BillingCycleOverride{
+		// 		{
+		// 			Sequence:    utils.ToPointer(1),
+		// 			TotalCycles: utils.ToPointer(1),
+		// 			PricingScheme: paypal.PricingScheme{
+		// 				FixedPrice: paypal.Money{
+		// 					Currency: money.Currency,
+		// 					Value:    "0",
+		// 				},
+		// 			},
+		// 		},
+		// 		{
+		// 			Sequence:    utils.ToPointer(2),
+		// 			TotalCycles: utils.ToPointer(0),
+		// 			PricingScheme: paypal.PricingScheme{
+		// 				FixedPrice: *money,
+		// 			},
+		// 		},
+		// 	},
+		// },
 	}
 
 	// Send subscription request to paypal.


### PR DESCRIPTION
Removes plan overrides which were causing "The override plan pricing scheme should be of the same type as that of the original plan." errors. The overrides were originally to have a single plan that used multiple currencies, but that is not viable to do anyway so the overrides are redundant. It is better to just change the pricing on paypal's site.