### PR TITLE
Fix prize adjustment logic and improve logging

### DIFF
--- a/jobs/finish-giveaways.go
+++ b/jobs/finish-giveaways.go
@@ -123,7 +123,7 @@ func entrypoint(ctx context.Context, webhookUrl string) {
 				Data:       data,
 			})
 			if err != nil {
-				welcomer.Logger.Warn().Err(err).Int64("guild_id", giveaway.GuildID).Str("identifier", locations[0].GetIdentifier()).Msg("Failed to relay end giveaway message")
+				welcomer.Logger.Warn().Err(err).Int64("guild_id", giveaway.GuildID).Str("identifier", location.GetIdentifier()).Msg("Failed to relay end giveaway message")
 
 				continue
 			}

--- a/welcomer-gateway/plugins/plugin_giveaways.go
+++ b/welcomer-gateway/plugins/plugin_giveaways.go
@@ -243,9 +243,9 @@ func (g *GiveawayCog) EndGiveaway(eventCtx *sandwich.EventContext, giveaway *dat
 	}
 
 	for i, prize := range prizes {
-		_, ok := wonPrizes[prize.Title]
+		count, ok := wonPrizes[prize.Title]
 		if ok {
-			prizes[i].Count -= prizes[i].Count
+			prizes[i].Count -= count
 		}
 	}
 

--- a/welcomer-interactions/plugins/plugin_debug.go
+++ b/welcomer-interactions/plugins/plugin_debug.go
@@ -178,7 +178,7 @@ func (cog *DebugCog) RegisterCog(sub *subway.Subway) error {
 
 	debugGroup.MustAddInteractionCommand(&subway.InteractionCommandable{
 		Name:        "testjoin",
-		Description: "Relays an GUILD_MEMBER_ADD event to consumers",
+		Description: "Relays a GUILD_MEMBER_ADD event to consumers",
 
 		Type: subway.InteractionCommandableTypeSubcommand,
 
@@ -230,7 +230,7 @@ func (cog *DebugCog) RegisterCog(sub *subway.Subway) error {
 
 	debugGroup.MustAddInteractionCommand(&subway.InteractionCommandable{
 		Name:        "testleave",
-		Description: "Relays an GUILD_MEMBER_REMOVE event to consumers",
+		Description: "Relays a GUILD_MEMBER_REMOVE event to consumers",
 
 		Type: subway.InteractionCommandableTypeSubcommand,
 


### PR DESCRIPTION
Correct the prize adjustment mechanism and enhance logging for failed giveaway finishes. Additionally, update interaction command descriptions for clarity.