### PR TITLE
Prevent processing of reaction roles when disabled

### DIFF
--- a/welcomer-backend/backend/routes_guild_settings_reactionroles.go
+++ b/welcomer-backend/backend/routes_guild_settings_reactionroles.go
@@ -228,7 +228,7 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 	} else if hasConfigurationChangedRoles(old, new) || old.Message != new.Message || old.Enabled != new.Enabled {
 		// If roles, message or enabled has changed, update existing message.
 
-		if !new.Enabled && !old.ChannelID.IsNil() && !old.MessageID.IsNil() {
+		if old != nil && !new.Enabled && !old.ChannelID.IsNil() && !old.MessageID.IsNil() {
 			err = disableReactionRoleMessage(ctx, old.ChannelID, old.MessageID)
 			if err != nil {
 				eg.Add(fmt.Errorf("failed to disable message for disabled system message reaction role configuration: %v", err))

--- a/welcomer-backend/backend/routes_guild_settings_reactionroles.go
+++ b/welcomer-backend/backend/routes_guild_settings_reactionroles.go
@@ -188,12 +188,13 @@ func processReactionRolesSettingsChange(ctx *gin.Context, old, new *GuildSetting
 }
 
 func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welcomer.ErrorGroup, old, new *welcomer.GuildSettingsReactionRole) {
-	// if old != nil && new == nil {
-	// 	err := disableReactionRoleMessage(ctx, old.ChannelID, old.MessageID)
-	// 	if err != nil {
-	// 		eg.Add(fmt.Errorf("failed to disable message for removed system message reaction role configuration: %v", err))
-	// 	}
-	// }
+	if old != nil {
+		old = &welcomer.GuildSettingsReactionRole{}
+	}
+
+	if new != nil {
+		new = &welcomer.GuildSettingsReactionRole{}
+	}
 
 	if !hasConfigurationChanged(old, new) {
 		return
@@ -202,7 +203,7 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 	var message *discord.Message
 	var err error
 
-	if hasConfigurationChangedMessage(old, new) && ((old == nil || new == nil) || old.ChannelID != new.ChannelID) {
+	if hasConfigurationChangedMessage(old, new) && (old.ChannelID != new.ChannelID) {
 		// If channel has changed, send new message.
 
 		if new != nil && new.Enabled {
@@ -280,6 +281,14 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 }
 
 func processReactionRolesSettingsChangeNonSystemMessage(ctx *gin.Context, eg *welcomer.ErrorGroup, old, new *welcomer.GuildSettingsReactionRole) {
+	if old != nil {
+		old = &welcomer.GuildSettingsReactionRole{}
+	}
+
+	if new != nil {
+		new = &welcomer.GuildSettingsReactionRole{}
+	}
+
 	if !new.Enabled || new.ChannelID.IsNil() || new.MessageID.IsNil() {
 		return
 	}

--- a/welcomer-backend/backend/routes_guild_settings_reactionroles.go
+++ b/welcomer-backend/backend/routes_guild_settings_reactionroles.go
@@ -247,6 +247,8 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 					welcomer.Logger.Warn().Err(err).Int64("guild_id", int64(tryGetGuildID(ctx))).Int64("channel_id", int64(new.ChannelID)).Msg("Failed to create message for updated system message reaction role configuration")
 				}
 
+				new.MessageID = message.ID
+
 				return
 			}
 		}

--- a/welcomer-backend/backend/routes_guild_settings_reactionroles.go
+++ b/welcomer-backend/backend/routes_guild_settings_reactionroles.go
@@ -188,12 +188,12 @@ func processReactionRolesSettingsChange(ctx *gin.Context, old, new *GuildSetting
 }
 
 func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welcomer.ErrorGroup, old, new *welcomer.GuildSettingsReactionRole) {
-	if old != nil && new == nil {
-		err := disableReactionRoleMessage(ctx, old.ChannelID, old.MessageID)
-		if err != nil {
-			eg.Add(fmt.Errorf("failed to disable message for removed system message reaction role configuration: %v", err))
-		}
-	}
+	// if old != nil && new == nil {
+	// 	err := disableReactionRoleMessage(ctx, old.ChannelID, old.MessageID)
+	// 	if err != nil {
+	// 		eg.Add(fmt.Errorf("failed to disable message for removed system message reaction role configuration: %v", err))
+	// 	}
+	// }
 
 	if !hasConfigurationChanged(old, new) {
 		return
@@ -218,7 +218,7 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 			}
 		}
 
-		if old != nil {
+		if old != nil && !old.ChannelID.IsNil() && !old.MessageID.IsNil() {
 			// Disable old message.
 			err = disableReactionRoleMessage(ctx, old.ChannelID, old.MessageID)
 			if err != nil {

--- a/welcomer-backend/backend/routes_guild_settings_reactionroles.go
+++ b/welcomer-backend/backend/routes_guild_settings_reactionroles.go
@@ -284,11 +284,7 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 	}
 }
 
-func processReactionRolesSettingsChangeNonSystemMessage(ctx *gin.Context, eg *welcomer.ErrorGroup, old, new *welcomer.GuildSettingsReactionRole) {
-	if old == nil {
-		old = &welcomer.GuildSettingsReactionRole{}
-	}
-
+func processReactionRolesSettingsChangeNonSystemMessage(ctx *gin.Context, eg *welcomer.ErrorGroup, _, new *welcomer.GuildSettingsReactionRole) {
 	if new == nil {
 		new = &welcomer.GuildSettingsReactionRole{}
 	}

--- a/welcomer-backend/backend/routes_guild_settings_reactionroles.go
+++ b/welcomer-backend/backend/routes_guild_settings_reactionroles.go
@@ -188,11 +188,11 @@ func processReactionRolesSettingsChange(ctx *gin.Context, old, new *GuildSetting
 }
 
 func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welcomer.ErrorGroup, old, new *welcomer.GuildSettingsReactionRole) {
-	if old != nil {
+	if old == nil {
 		old = &welcomer.GuildSettingsReactionRole{}
 	}
 
-	if new != nil {
+	if new == nil {
 		new = &welcomer.GuildSettingsReactionRole{}
 	}
 
@@ -281,11 +281,11 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 }
 
 func processReactionRolesSettingsChangeNonSystemMessage(ctx *gin.Context, eg *welcomer.ErrorGroup, old, new *welcomer.GuildSettingsReactionRole) {
-	if old != nil {
+	if old == nil {
 		old = &welcomer.GuildSettingsReactionRole{}
 	}
 
-	if new != nil {
+	if new == nil {
 		new = &welcomer.GuildSettingsReactionRole{}
 	}
 

--- a/welcomer-backend/backend/routes_guild_settings_reactionroles.go
+++ b/welcomer-backend/backend/routes_guild_settings_reactionroles.go
@@ -205,7 +205,7 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 	if hasConfigurationChangedMessage(old, new) && ((old == nil || new == nil) || old.ChannelID != new.ChannelID) {
 		// If channel has changed, send new message.
 
-		if new != nil {
+		if new != nil && new.Enabled {
 			message, err = createReactionRoleMessage(ctx, eg, new)
 			if err != nil {
 				welcomer.Logger.Warn().Err(err).Int64("guild_id", int64(tryGetGuildID(ctx))).Int64("channel_id", int64(new.ChannelID)).Msg("Failed to create message for updated system message reaction role configuration")
@@ -228,8 +228,8 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 	} else if hasConfigurationChangedRoles(old, new) || old.Message != new.Message || old.Enabled != new.Enabled {
 		// If roles, message or enabled has changed, update existing message.
 
-		if !new.Enabled {
-			err = disableReactionRoleMessage(ctx, new.ChannelID, new.MessageID)
+		if !new.Enabled && !old.ChannelID.IsNil() && !old.MessageID.IsNil() {
+			err = disableReactionRoleMessage(ctx, old.ChannelID, old.MessageID)
 			if err != nil {
 				eg.Add(fmt.Errorf("failed to disable message for disabled system message reaction role configuration: %v", err))
 			}
@@ -278,6 +278,10 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 }
 
 func processReactionRolesSettingsChangeNonSystemMessage(ctx *gin.Context, eg *welcomer.ErrorGroup, old, new *welcomer.GuildSettingsReactionRole) {
+	if !new.Enabled || new.ChannelID.IsNil() || new.MessageID.IsNil() {
+		return
+	}
+
 	message, err := discord.GetChannelMessage(ctx, backend.BotSession, new.ChannelID, new.MessageID)
 	if err != nil {
 		welcomer.Logger.Warn().Err(err).Int64("guild_id", int64(tryGetGuildID(ctx))).Int64("channel_id", int64(new.ChannelID)).Int64("message_id", int64(new.MessageID)).Msg("Failed to get message for updated system message reaction role configuration")
@@ -714,10 +718,6 @@ func doValidateReactionRoles(ctx context.Context, guildID discord.Snowflake, par
 	}
 
 	for reactionRoleIndex, reactionRole := range partial.ReactionRoles {
-		if !reactionRole.Enabled {
-			continue
-		}
-
 		if reactionRole.ChannelID != 0 {
 			validGuild, err := welcomer.CheckChannelGuild(ctx, welcomer.SandwichClient, guildID, reactionRole.ChannelID)
 			if err != nil {
@@ -735,6 +735,10 @@ func doValidateReactionRoles(ctx context.Context, guildID discord.Snowflake, par
 
 				continue
 			}
+		}
+
+		if !reactionRole.Enabled {
+			continue
 		}
 
 		if reactionRole.IsSystemMessage {

--- a/welcomer-backend/backend/routes_guild_settings_reactionroles.go
+++ b/welcomer-backend/backend/routes_guild_settings_reactionroles.go
@@ -248,7 +248,11 @@ func processReactionRolesSettingsChangeSystemMessage(ctx *gin.Context, eg *welco
 					welcomer.Logger.Warn().Err(err).Int64("guild_id", int64(tryGetGuildID(ctx))).Int64("channel_id", int64(new.ChannelID)).Msg("Failed to create message for updated system message reaction role configuration")
 				}
 
-				new.MessageID = message.ID
+				if message != nil {
+					new.MessageID = message.ID
+				} else {
+					new.MessageID = 0
+				}
 
 				return
 			}


### PR DESCRIPTION
Ensure that reaction role messages are only sent or processed when enabled. This change prevents sending messages if the reaction roles are disabled or if the channel has changed, and it validates channels even when reaction roles are disabled.